### PR TITLE
Disabling extension on Google domains.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,6 +6,7 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
+      "exclude_matches": [ "*://*.google.com/*" ],
       "js": ["content.js"]
     }
   ]


### PR DESCRIPTION
This restores paste functionality to Google Docs.
Specifically, multi-line pastes into Google Sheets.
