### PR TITLE
Allow copying in addition to pasting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Don't fuck with paste
+# Don't fuck with copy and paste
 
 ## Background
 
 It annoys me to no end when a web application prevents me from being
-able to paste content into an input field.  If I paste an incorrect
+able to paste content into an input field, or copy it out.  If I paste an incorrect
 email address, that's my own damn fault.  I use tools like 1Password to
 remember all kinds of things for me, and it's actually more error prone
 for me to type out all the characters than it is for me to copy from
@@ -11,13 +11,13 @@ for me to type out all the characters than it is for me to copy from
 
 ## Solution
 
-This is a dead simple Google Chrome extension that removes paste
-blocking.
+This is a dead simple Google Chrome extension that removes copy and 
+paste blocking.
 
 ## Configuration
 
-There are some sites that do helpful things with paste events, and for those
-sites you want their paste event handlers to still work. In the options for
-this extension, you can add an exclusion pattern that matches the site's URL,
-which will prevent this extension from running on that site, and thereby
+There are some sites that do helpful things with copy and paste events, and for
+those sites you want their paste event handlers to still work. In the options
+for this extension, you can add an exclusion pattern that matches the site's
+URL, which will prevent this extension from running on that site, and thereby
 allowing the paste event to occur.

--- a/content.js
+++ b/content.js
@@ -1,4 +1,4 @@
-const allowPaste = function(e){
+const allowCopyAndPaste = function(e){
   e.stopImmediatePropagation();
   return true;
 };
@@ -9,6 +9,7 @@ chrome.storage.sync.get(window.defaultValues, function({exclude, include}) {
   const location = window.location.href;
 
   if (includes.test(location) && !excludes.test(location)) {
-    document.addEventListener('paste', allowPaste, true);
+    document.addEventListener('copy', allowCopyAndPaste, true);
+    document.addEventListener('paste', allowCopyAndPaste, true);
   }
 });

--- a/test/iframe.html
+++ b/test/iframe.html
@@ -1,8 +1,8 @@
 <script src="script.js"></script>
 <p>(This is a form inside of an iframe.)</p>
 <form>
-  <label for="unpastable">Go ahead, try to paste</label>
-  <input id="attribute" type="text" onpaste="return false;" />
+  <label for="unpastable">Go ahead, try to copy or paste</label>
+  <input id="attribute" type="text" oncopy="return false;" onpaste="return false;" />
   <input id="property" type="text" />
   <input id="listener" type="text" />
 </form>

--- a/test/index.html
+++ b/test/index.html
@@ -4,12 +4,12 @@
     <script src="script.js"></script>
   </head>
   <body>
-    <p>The input boxes below doesn't let you paste stuff into it; every time a
-    page like this is created, a kitten is killed.</p>
+    <p>The input boxes below doesn't let you copy or paste stuff in it; every
+    time a page like this is created, a kitten is killed.</p>
     <p>(This is a form in the root document.)</p>
     <form>
       <p>Go ahead, try to paste:</p>
-      <input id="attribute" type="text" onpaste="return false;" />
+      <input id="attribute" type="text" oncopy="return false;" onpaste="return false;" />
       <input id="property" type="text" />
       <input id="listener" type="text" />
     </form>

--- a/test/script.js
+++ b/test/script.js
@@ -1,5 +1,7 @@
 window.onload = function(){
-  var preventPaste = function(e){ e.preventDefault(); }
-  document.getElementById('property').onpaste = preventPaste;
-  document.getElementById('listener').addEventListener('paste', preventPaste, false);
+  var preventCopyAndPaste = function(e){ e.preventDefault(); }
+  document.getElementById('property').onpaste = preventCopyAndPaste;
+  document.getElementById('property').oncopy = preventCopyAndPaste;
+  document.getElementById('listener').addEventListener('copy', preventCopyAndPaste, false);
+  document.getElementById('listener').addEventListener('paste', preventCopyAndPaste, false);
 };


### PR DESCRIPTION
A lot of forms want you to type the same thing twice, to prove you
didn't make a typo or whatever. Not being able to copy the thing you
just typed is just as bad as not being able to paste it into the next
form field.