### PR TITLE
feat(contextMenu): allow to quickly exclude page

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,0 +1,80 @@
+const EXCLUDE_PAGE_ID = 'exclude-page';
+
+function addUrlToArray(url, arr) {
+  // adds the given url to the array
+  return (arr || '')
+    .split('\n')
+    .concat([url])
+    .filter(function(value, index, self) {
+      return self.indexOf(value) === index;
+    })
+    .join('\n');
+}
+
+function removeUrlFromArray(url, arr) {
+  // removes the given url from the array
+  return (arr || '')
+    .split('\n')
+    .filter(function(value) {
+      return value !== url;
+    })
+    .join('\n');
+}
+
+function excludeUrl(url) {
+  chrome.storage.sync.get(window.defaultValues, function({ exclude, include }) {
+    chrome.storage.sync.set({
+      exclude: addUrlToArray(url, exclude),
+      include: removeUrlFromArray(url, include),
+    });
+
+    updateContextMenu(false);
+  });
+}
+
+function updateContextMenu(enabled) {
+  chrome.contextMenus.update(EXCLUDE_PAGE_ID, { enabled });
+}
+
+function updateContextMenuByUrl(url) {
+  // update the context menu based off the given url
+  chrome.storage.sync.get(window.defaultValues, function({ exclude, include }) {
+    const excludes = new RegExp(exclude.split('\n').join('|'));
+    const includes = new RegExp(include.split('\n').join('|'));
+
+    updateContextMenu(includes.test(url) && !excludes.test(url));
+  });
+}
+
+chrome.runtime.onInstalled.addListener(function() {
+  // When the app gets installed, set up the context menus
+  chrome.contextMenus.create({
+    id: EXCLUDE_PAGE_ID,
+    contexts: ['page_action'],
+    title: 'Exclude this page',
+    onclick: function(tab, page) {
+      excludeUrl(page.url);
+    },
+  });
+
+  chrome.tabs.query({ active: true }, function(tabs) {
+    // update the context menu with the current tab
+    if (tabs[0]) {
+      updateContextMenuByUrl(tabs[0].url);
+    }
+  });
+});
+
+chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab) {
+  // update the context menu when user updates url
+  if (tab.active && changeInfo.url) {
+    updateContextMenuByUrl(tab.url);
+  }
+});
+
+chrome.tabs.onActivated.addListener(function({ tabId }) {
+  // update the context menu when user changes tabs
+  chrome.tabs.get(tabId, function(tab) {
+    updateContextMenuByUrl(tab.url);
+  });
+});

--- a/manifest.json
+++ b/manifest.json
@@ -2,10 +2,7 @@
   "content_scripts": [
     {
       "all_frames": true,
-      "js": [
-        "defaults.js",
-        "content.js"
-      ],
+      "js": ["defaults.js", "content.js"],
       "matches": ["<all_urls>"]
     }
   ],
@@ -13,12 +10,11 @@
   "homepage_url": "https://github.com/jswanner/DontFuckWithPaste",
   "manifest_version": 2,
   "name": "Don't Fuck With Paste",
+  "background": { "scripts": ["background.js"] },
   "options_ui": {
     "chrome_style": true,
     "page": "options.html"
   },
-  "permissions": [
-    "storage"
-  ],
+  "permissions": ["storage", "contextMenus", "tabs"],
   "version": "1.1"
 }


### PR DESCRIPTION
feat(contextMenu): add a context menu option that allows you to quickly exclude the current page’s url

![image](https://user-images.githubusercontent.com/7423098/29574047-10ae6cca-8726-11e7-82bd-450c76cde960.png)
