### PR TITLE
Whatsapp Web exclude by default

### DIFF
--- a/defaults.js
+++ b/defaults.js
@@ -1,7 +1,8 @@
 const exclude = `https?://.*?\.facebook\.com/.*
 https?://.*?.google.com/.*
 https?://.*?.?github.com/.*
-https?://imgur.com/.*`;
+https?://imgur.com/.*
+https?://web.whatsapp.com/?.*`;
 
 window.defaultValues = {
   exclude,


### PR DESCRIPTION
Copying a raw image then attempting to paste into Whatsapp Web would not work, so added it to the excludes for a 'fix'