### PR TITLE
Feature/unblock more events

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ paste into a text box.
 ## Solution
 
 This is a dead simple Google Chrome extension that removes copy, cut and paste
-blocking. It also removes more blocking of related features such as
+blocking. It also removes blocking of related features such as
 Ctrl key shortcuts, right-clicking, selecting areas to copy, 
 and the browser context menu.
 

--- a/README.md
+++ b/README.md
@@ -24,4 +24,4 @@ There are some sites that do helpful things with copy and paste events, and for
 those sites you want their event handlers to still work. In the options
 for this extension, you can add an exclusion pattern that matches the site's
 URL, which will prevent this extension from running on that site, and thereby
-allowing the paste event to occur.
+allowing the site's own event actions to occur.

--- a/README.md
+++ b/README.md
@@ -24,4 +24,4 @@ There are some sites that do helpful things with copy and paste events, and for
 those sites you want their event handlers to still work. In the options
 for this extension, you can add an exclusion pattern that matches the site's
 URL, which will prevent this extension from running on that site, and thereby
-allowing the site's own event actions to occur.
+allowing the paste event to occur.

--- a/README.md
+++ b/README.md
@@ -13,13 +13,15 @@ paste into a text box.
 
 ## Solution
 
-This is a dead simple Google Chrome extension that removes copy and paste
-blocking.
+This is a dead simple Google Chrome extension that removes copy, cut and paste
+blocking. It also removes more blocking of related features such as
+Ctrl key shortcuts, right-clicking, selecting areas to copy, 
+and the browser context menu.
 
 ## Configuration
 
 There are some sites that do helpful things with copy and paste events, and for
-those sites you want their paste event handlers to still work. In the options
+those sites you want their event handlers to still work. In the options
 for this extension, you can add an exclusion pattern that matches the site's
 URL, which will prevent this extension from running on that site, and thereby
 allowing the paste event to occur.

--- a/content.js
+++ b/content.js
@@ -1,6 +1,17 @@
-const allowEvent = function(e){
+const doNotPropagate = function(e){
   e.stopImmediatePropagation();
   return true;
+};
+
+const doNotPropagateCtrl = function(e){
+  if (e.type !== "keydown") return false;
+
+  var keyCode = e.which;
+  var CTRL_KEY_CODE = 17;
+
+  if (parseInt(keyCode) !== CTRL_KEY_CODE) return false;
+
+  return doNotPropagate(e);
 };
 
 chrome.storage.sync.get(window.defaultValues, function({exclude, include}) {
@@ -9,9 +20,9 @@ chrome.storage.sync.get(window.defaultValues, function({exclude, include}) {
   const location = window.location.href;
 
   if (includes.test(location) && !excludes.test(location)) {
-    document.addEventListener('cut', allowEvent, true);
-    document.addEventListener('copy', allowEvent, true);
-    document.addEventListener('paste', allowEvent, true);
-    document.addEventListener('keydown', allowEvent, true);
+    document.addEventListener('cut', doNotPropagate, true);
+    document.addEventListener('copy', doNotPropagate, true);
+    document.addEventListener('paste', doNotPropagate, true);
+    document.addEventListener('keydown', doNotPropagateCtrl, true);
   }
 });

--- a/content.js
+++ b/content.js
@@ -12,5 +12,6 @@ chrome.storage.sync.get(window.defaultValues, function({exclude, include}) {
     document.addEventListener('cut', allowEvent, true);
     document.addEventListener('copy', allowEvent, true);
     document.addEventListener('paste', allowEvent, true);
+    document.addEventListener('keydown', allowEvent, true);
   }
 });

--- a/content.js
+++ b/content.js
@@ -1,24 +1,25 @@
-const doNotPropagate = function(e){
+const allowDefaultAction = function(e){
+  // prevent custom event handlers on the page swallowing the event
   e.stopImmediatePropagation();
   return true;
 };
 
-const doNotPropagateCtrl = function(e){
+const allowDefaultCtrlAction = function(e){
   if (e.type !== "keydown") return false;
 
   const CTRL_KEY_CODE = 17;
   if (parseInt(e.keyCode) !== CTRL_KEY_CODE) return false;
 
-  return doNotPropagate(e);
+  return allowDefaultAction(e);
 };
 
-const doNotPropagateRightClick = function(e){
+const allowDefaultRightClickAction = function(e){
   if (e.type !== "mousedown") return false;
 
   const RIGHT_CLICK = 2;
   if (e.button !== RIGHT_CLICK) return false;
 
-  return doNotPropagate(e);
+  return allowDefaultAction(e);
 };
 
 chrome.storage.sync.get(window.defaultValues, function({exclude, include}) {
@@ -27,10 +28,11 @@ chrome.storage.sync.get(window.defaultValues, function({exclude, include}) {
   const location = window.location.href;
 
   if (includes.test(location) && !excludes.test(location)) {
-    document.addEventListener('cut', doNotPropagate, true);
-    document.addEventListener('copy', doNotPropagate, true);
-    document.addEventListener('paste', doNotPropagate, true);
-    document.addEventListener('keydown', doNotPropagateCtrl, true);
-    document.addEventListener('mousedown', doNotPropagateRightClick, true);
+    document.addEventListener('cut', allowDefaultAction, true);
+    document.addEventListener('copy', allowDefaultAction, true);
+    document.addEventListener('paste', allowDefaultAction, true);
+    document.addEventListener('keydown', allowDefaultCtrlAction, true);
+    document.addEventListener('mousedown', allowDefaultRightClickAction, true);
+    document.addEventListener('contextmenu', allowDefaultAction, true);
   }
 });

--- a/content.js
+++ b/content.js
@@ -34,5 +34,6 @@ chrome.storage.sync.get(window.defaultValues, function({exclude, include}) {
     document.addEventListener('keydown', allowDefaultCtrlAction, true);
     document.addEventListener('mousedown', allowDefaultRightClickAction, true);
     document.addEventListener('contextmenu', allowDefaultAction, true);
+    document.addEventListener('selectstart', allowDefaultAction, true);
   }
 });

--- a/content.js
+++ b/content.js
@@ -6,10 +6,17 @@ const doNotPropagate = function(e){
 const doNotPropagateCtrl = function(e){
   if (e.type !== "keydown") return false;
 
-  var keyCode = e.which;
-  var CTRL_KEY_CODE = 17;
+  const CTRL_KEY_CODE = 17;
+  if (parseInt(e.keyCode) !== CTRL_KEY_CODE) return false;
 
-  if (parseInt(keyCode) !== CTRL_KEY_CODE) return false;
+  return doNotPropagate(e);
+};
+
+const doNotPropagateRightClick = function(e){
+  if (e.type !== "mousedown") return false;
+
+  const RIGHT_CLICK = 2;
+  if (e.button !== RIGHT_CLICK) return false;
 
   return doNotPropagate(e);
 };
@@ -24,5 +31,6 @@ chrome.storage.sync.get(window.defaultValues, function({exclude, include}) {
     document.addEventListener('copy', doNotPropagate, true);
     document.addEventListener('paste', doNotPropagate, true);
     document.addEventListener('keydown', doNotPropagateCtrl, true);
+    document.addEventListener('mousedown', doNotPropagateRightClick, true);
   }
 });

--- a/content.js
+++ b/content.js
@@ -1,4 +1,4 @@
-const allowCopyAndPaste = function(e){
+const allowEvent = function(e){
   e.stopImmediatePropagation();
   return true;
 };
@@ -9,7 +9,8 @@ chrome.storage.sync.get(window.defaultValues, function({exclude, include}) {
   const location = window.location.href;
 
   if (includes.test(location) && !excludes.test(location)) {
-    document.addEventListener('copy', allowCopyAndPaste, true);
-    document.addEventListener('paste', allowCopyAndPaste, true);
+    document.addEventListener('cut', allowEvent, true);
+    document.addEventListener('copy', allowEvent, true);
+    document.addEventListener('paste', allowEvent, true);
   }
 });

--- a/test/iframe.html
+++ b/test/iframe.html
@@ -1,7 +1,7 @@
 <script src="script.js"></script>
 <p>(This is a form inside of an iframe.)</p>
 <form>
-  <label for="unpastable">Go ahead, try to copy or paste</label>
+  <label for="unpastable">Go ahead, try to copy or paste:</label>
   <input id="attribute" type="text" oncopy="return false;" onpaste="return false;" />
   <input id="property" type="text" />
   <input id="listener" type="text" />

--- a/test/iframe.html
+++ b/test/iframe.html
@@ -2,7 +2,8 @@
 <p>(This is a form inside of an iframe.)</p>
 <form>
   <label>Go ahead, try to copy or paste:</label>
-  <input id="attribute" type="text" oncopy="return false;" onpaste="return false;" oncut="return false;" onkeydown="return alertOnCtrl(event);"/>
+  <input id="attribute" type="text" oncopy="return false;" onpaste="return false;" oncut="return false;"
+         onkeydown="return alertOnCtrl(event);" onmousedown="return alertOnRightClick(event);"/>
   <input id="property" type="text" />
   <input id="listener" type="text" />
 </form>

--- a/test/iframe.html
+++ b/test/iframe.html
@@ -3,7 +3,8 @@
 <form>
   <label>Go ahead, try to copy or paste:</label>
   <input id="attribute" type="text" oncopy="return false;" onpaste="return false;" oncut="return false;"
-         onkeydown="return alertOnCtrl(event);" onmousedown="return alertOnRightClick(event);"/>
+         onkeydown="return alertOnCtrl(event);"
+         onmousedown="return alertOnRightClick(event);" oncontextmenu="return false;"/>
   <input id="property" type="text" />
   <input id="listener" type="text" />
 </form>

--- a/test/iframe.html
+++ b/test/iframe.html
@@ -2,7 +2,7 @@
 <p>(This is a form inside of an iframe.)</p>
 <form>
   <label for="unpastable">Go ahead, try to copy or paste:</label>
-  <input id="attribute" type="text" oncopy="return false;" onpaste="return false;" />
+  <input id="attribute" type="text" oncopy="return false;" onpaste="return false;" oncut="return false;"/>
   <input id="property" type="text" />
   <input id="listener" type="text" />
 </form>

--- a/test/iframe.html
+++ b/test/iframe.html
@@ -2,7 +2,7 @@
 <p>(This is a form inside of an iframe.)</p>
 <form>
   <label>Go ahead, try to copy or paste:</label>
-  <input id="attribute" type="text" oncopy="return false;" onpaste="return false;" oncut="return false;"/>
+  <input id="attribute" type="text" oncopy="return false;" onpaste="return false;" oncut="return false;" onkeydown="return alertOnCtrl(event);"/>
   <input id="property" type="text" />
   <input id="listener" type="text" />
 </form>

--- a/test/iframe.html
+++ b/test/iframe.html
@@ -1,7 +1,7 @@
 <script src="script.js"></script>
 <p>(This is a form inside of an iframe.)</p>
 <form>
-  <label for="unpastable">Go ahead, try to copy or paste:</label>
+  <label>Go ahead, try to copy or paste:</label>
   <input id="attribute" type="text" oncopy="return false;" onpaste="return false;" oncut="return false;"/>
   <input id="property" type="text" />
   <input id="listener" type="text" />

--- a/test/iframe.html
+++ b/test/iframe.html
@@ -1,6 +1,6 @@
 <script src="script.js"></script>
-<p>(This is a form inside of an iframe.)</p>
-<form>
+<p onselectstart="return false;" >(This is a form inside of an iframe.)</p>
+<form onselectstart="return false;" >
   <label>Go ahead, try to copy or paste:</label>
   <input id="attribute" type="text" oncopy="return false;" onpaste="return false;" oncut="return false;"
          onkeydown="return alertOnCtrl(event);"

--- a/test/index.html
+++ b/test/index.html
@@ -9,7 +9,7 @@
     <p>(This is a form in the root document.)</p>
     <form>
       <p>Go ahead, try to cut, copy or paste:</p>
-      <input id="attribute" type="text" oncopy="return false;" onpaste="return false;" oncut="return false;" onkeydown="return noCTRL(event);"/>
+      <input id="attribute" type="text" oncopy="return false;" onpaste="return false;" oncut="return false;" onkeydown="return alertOnCtrl(event);"/>
       <input id="property" type="text" />
       <input id="listener" type="text" />
     </form>

--- a/test/index.html
+++ b/test/index.html
@@ -3,7 +3,7 @@
     <title>I'm fucking with paste</title>
     <script src="script.js"></script>
   </head>
-  <body>
+  <body onselectstart="return false;">
     <p>The input boxes below doesn't let you copy or paste stuff in it; every
     time a page like this is created, a kitten is killed.</p>
     <p>(This is a form in the root document.)</p>

--- a/test/index.html
+++ b/test/index.html
@@ -8,7 +8,7 @@
     time a page like this is created, a kitten is killed.</p>
     <p>(This is a form in the root document.)</p>
     <form>
-      <p>Go ahead, try to paste:</p>
+      <p>Go ahead, try to copy or paste:</p>
       <input id="attribute" type="text" oncopy="return false;" onpaste="return false;" />
       <input id="property" type="text" />
       <input id="listener" type="text" />

--- a/test/index.html
+++ b/test/index.html
@@ -10,7 +10,8 @@
     <form>
       <p>Go ahead, try to cut, copy or paste:</p>
       <input id="attribute" type="text" oncopy="return false;" onpaste="return false;" oncut="return false;"
-             onkeydown="return alertOnCtrl(event);" onmousedown="return alertOnRightClick(event);" />
+             onkeydown="return alertOnCtrl(event);"
+             onmousedown="return alertOnRightClick(event);" oncontextmenu="return false;"/>
       <input id="property" type="text" />
       <input id="listener" type="text" />
     </form>

--- a/test/index.html
+++ b/test/index.html
@@ -8,8 +8,8 @@
     time a page like this is created, a kitten is killed.</p>
     <p>(This is a form in the root document.)</p>
     <form>
-      <p>Go ahead, try to copy or paste:</p>
-      <input id="attribute" type="text" oncopy="return false;" onpaste="return false;" />
+      <p>Go ahead, try to cut, copy or paste:</p>
+      <input id="attribute" type="text" oncopy="return false;" onpaste="return false;" oncut="return false;"/>
       <input id="property" type="text" />
       <input id="listener" type="text" />
     </form>

--- a/test/index.html
+++ b/test/index.html
@@ -9,7 +9,7 @@
     <p>(This is a form in the root document.)</p>
     <form>
       <p>Go ahead, try to cut, copy or paste:</p>
-      <input id="attribute" type="text" oncopy="return false;" onpaste="return false;" oncut="return false;"/>
+      <input id="attribute" type="text" oncopy="return false;" onpaste="return false;" oncut="return false;" onkeydown="return noCTRL(event);"/>
       <input id="property" type="text" />
       <input id="listener" type="text" />
     </form>

--- a/test/index.html
+++ b/test/index.html
@@ -9,7 +9,8 @@
     <p>(This is a form in the root document.)</p>
     <form>
       <p>Go ahead, try to cut, copy or paste:</p>
-      <input id="attribute" type="text" oncopy="return false;" onpaste="return false;" oncut="return false;" onkeydown="return alertOnCtrl(event);"/>
+      <input id="attribute" type="text" oncopy="return false;" onpaste="return false;" oncut="return false;"
+             onkeydown="return alertOnCtrl(event);" onmousedown="return alertOnRightClick(event);" />
       <input id="property" type="text" />
       <input id="listener" type="text" />
     </form>

--- a/test/script.js
+++ b/test/script.js
@@ -1,3 +1,14 @@
+function noCTRL(e) {
+    var code = (document.all) ? event.keyCode : e.which;
+
+    var msg = "Copy and Paste is not allowed.";
+    if (parseInt(code) == 17) //CTRL
+    {
+        //alert(msg);
+        window.event.returnValue = false;
+    }
+}
+
 window.onload = function(){
   var prevent = function(e){ e.preventDefault(); }
 

--- a/test/script.js
+++ b/test/script.js
@@ -1,8 +1,7 @@
 function alertOnCtrl(e) {
-  const keyCode = event.keyCode || e.which;
   const CTRL_KEY_CODE = 17;
 
-  if (parseInt(keyCode) === CTRL_KEY_CODE) {
+  if (parseInt(e.keyCode) === CTRL_KEY_CODE) {
     // popping up an alert box is enough to stop default event handling in chrome!
     alert("ctrl shortcuts are blocked");
   }
@@ -13,8 +12,8 @@ function alertOnCtrl(e) {
 function alertOnRightClick(e) {
   const RIGHT_CLICK = 2;
 
-  if (event.button === RIGHT_CLICK) {
-    alert("right mouse button is blocked");
+  if (e.button === RIGHT_CLICK) {
+    alert("right click menu is blocked");
   }
 
   return true;
@@ -22,7 +21,7 @@ function alertOnRightClick(e) {
 
 
 window.onload = function(){
-  var preventEvent = function(e){ e.preventDefault(); };
+  const preventEvent = function(e){ e.preventDefault(); };
 
   document.getElementById('property').onpaste = preventEvent;
   document.getElementById('property').oncopy = preventEvent;

--- a/test/script.js
+++ b/test/script.js
@@ -28,10 +28,12 @@ window.onload = function(){
   document.getElementById('property').oncut = preventEvent;
   document.getElementById('property').onkeydown = alertOnCtrl;
   document.getElementById('property').onmousedown = alertOnRightClick;
+  document.getElementById('property').oncontextmenu = preventEvent;
 
   document.getElementById('listener').addEventListener('copy', preventEvent, false);
   document.getElementById('listener').addEventListener('paste', preventEvent, false);
   document.getElementById('listener').addEventListener('cut', preventEvent, false);
   document.getElementById('listener').addEventListener('keydown', alertOnCtrl, false);
   document.getElementById('listener').addEventListener('mousedown', alertOnRightClick, false);
+  document.getElementById('listener').addEventListener('contextmenu', preventEvent, false);
 };

--- a/test/script.js
+++ b/test/script.js
@@ -1,22 +1,24 @@
-function noCTRL(e) {
-    var code = (document.all) ? event.keyCode : e.which;
+function alertOnCtrl(e) {
+    var keyCode = event.keyCode || e.which;
+    var CTRL_KEY_CODE = 17;
 
-    var msg = "Copy and Paste is not allowed.";
-    if (parseInt(code) == 17) //CTRL
-    {
-        //alert(msg);
-        window.event.returnValue = false;
+    if (parseInt(keyCode) == CTRL_KEY_CODE) {
+      alert("ctrl shortcuts are blocked");
     }
+
+    return true;
 }
 
 window.onload = function(){
-  var prevent = function(e){ e.preventDefault(); }
+  var preventEvent = function(e){ e.preventDefault(); }
 
-  document.getElementById('property').onpaste = prevent;
-  document.getElementById('property').oncopy = prevent;
-  document.getElementById('property').oncut = prevent;
+  document.getElementById('property').onpaste = preventEvent;
+  document.getElementById('property').oncopy = preventEvent;
+  document.getElementById('property').oncut = preventEvent;
+  document.getElementById('property').onkeydown = alertOnCtrl;
 
-  document.getElementById('listener').addEventListener('copy', prevent, false);
-  document.getElementById('listener').addEventListener('paste', prevent, false);
-  document.getElementById('listener').addEventListener('cut', prevent, false);
+  document.getElementById('listener').addEventListener('copy', preventEvent, false);
+  document.getElementById('listener').addEventListener('paste', preventEvent, false);
+  document.getElementById('listener').addEventListener('cut', preventEvent, false);
+  document.getElementById('listener').addEventListener('keydown', alertOnCtrl, false);
 };

--- a/test/script.js
+++ b/test/script.js
@@ -1,12 +1,12 @@
 function alertOnCtrl(e) {
-    var keyCode = event.keyCode || e.which;
-    var CTRL_KEY_CODE = 17;
+  var keyCode = event.keyCode || e.which;
+  var CTRL_KEY_CODE = 17;
 
-    if (parseInt(keyCode) === CTRL_KEY_CODE) {
-      alert("ctrl shortcuts are blocked");
-    }
+  if (parseInt(keyCode) === CTRL_KEY_CODE) {
+    alert("ctrl shortcuts are blocked");
+  }
 
-    return true;
+  return true;
 }
 
 window.onload = function(){

--- a/test/script.js
+++ b/test/script.js
@@ -2,7 +2,7 @@ function alertOnCtrl(e) {
     var keyCode = event.keyCode || e.which;
     var CTRL_KEY_CODE = 17;
 
-    if (parseInt(keyCode) == CTRL_KEY_CODE) {
+    if (parseInt(keyCode) === CTRL_KEY_CODE) {
       alert("ctrl shortcuts are blocked");
     }
 
@@ -10,7 +10,7 @@ function alertOnCtrl(e) {
 }
 
 window.onload = function(){
-  var preventEvent = function(e){ e.preventDefault(); }
+  var preventEvent = function(e){ e.preventDefault(); };
 
   document.getElementById('property').onpaste = preventEvent;
   document.getElementById('property').oncopy = preventEvent;

--- a/test/script.js
+++ b/test/script.js
@@ -1,13 +1,25 @@
 function alertOnCtrl(e) {
-  var keyCode = event.keyCode || e.which;
-  var CTRL_KEY_CODE = 17;
+  const keyCode = event.keyCode || e.which;
+  const CTRL_KEY_CODE = 17;
 
   if (parseInt(keyCode) === CTRL_KEY_CODE) {
+    // popping up an alert box is enough to stop default event handling in chrome!
     alert("ctrl shortcuts are blocked");
   }
 
   return true;
 }
+
+function alertOnRightClick(e) {
+  const RIGHT_CLICK = 2;
+
+  if (event.button === RIGHT_CLICK) {
+    alert("right mouse button is blocked");
+  }
+
+  return true;
+}
+
 
 window.onload = function(){
   var preventEvent = function(e){ e.preventDefault(); };
@@ -16,9 +28,11 @@ window.onload = function(){
   document.getElementById('property').oncopy = preventEvent;
   document.getElementById('property').oncut = preventEvent;
   document.getElementById('property').onkeydown = alertOnCtrl;
+  document.getElementById('property').onmousedown = alertOnRightClick;
 
   document.getElementById('listener').addEventListener('copy', preventEvent, false);
   document.getElementById('listener').addEventListener('paste', preventEvent, false);
   document.getElementById('listener').addEventListener('cut', preventEvent, false);
   document.getElementById('listener').addEventListener('keydown', alertOnCtrl, false);
+  document.getElementById('listener').addEventListener('mousedown', alertOnRightClick, false);
 };

--- a/test/script.js
+++ b/test/script.js
@@ -1,7 +1,11 @@
 window.onload = function(){
-  var preventCopyAndPaste = function(e){ e.preventDefault(); }
-  document.getElementById('property').onpaste = preventCopyAndPaste;
-  document.getElementById('property').oncopy = preventCopyAndPaste;
-  document.getElementById('listener').addEventListener('copy', preventCopyAndPaste, false);
-  document.getElementById('listener').addEventListener('paste', preventCopyAndPaste, false);
+  var prevent = function(e){ e.preventDefault(); }
+
+  document.getElementById('property').onpaste = prevent;
+  document.getElementById('property').oncopy = prevent;
+  document.getElementById('property').oncut = prevent;
+
+  document.getElementById('listener').addEventListener('copy', prevent, false);
+  document.getElementById('listener').addEventListener('paste', prevent, false);
+  document.getElementById('listener').addEventListener('cut', prevent, false);
 };


### PR DESCRIPTION
Unblock copy and paste on more sites, and unblock cut in general
* Add cut to the list of events which can be unblocked
* Unblock on sites which capture Ctrl key or right-click events
* Unblock accessing the context menu
* Unblock selecting text to copy when outside form inputs
* Add tests for all the above

* Fix some intellij JS warnings
* Rename some functions - possibly controversial :)

The new unblockings will probably break some sites with rich content editors, necessitating more use of the site whitelist/blacklist by users.